### PR TITLE
Update providers.tf

### DIFF
--- a/cluster/providers.tf
+++ b/cluster/providers.tf
@@ -27,7 +27,7 @@ terraform {
 # These providers aren't needed until after the cluster has been bootstrapped
 
 provider "helm" {
-  kubernetes = {
+  kubernetes {
     host                   = talos_cluster_kubeconfig.kubeconfig.kubernetes_client_configuration.host
     cluster_ca_certificate = base64decode(talos_cluster_kubeconfig.kubeconfig.kubernetes_client_configuration.ca_certificate)
 


### PR DESCRIPTION
Removing an errant '=' sign per helm provider documentation: https://registry.terraform.io/providers/hashicorp/helm/latest/docs#credentials-config